### PR TITLE
Start Demonsaw at boot, and stop it when needed.

### DIFF
--- a/Router Resources/init.d/demonsaw
+++ b/Router Resources/init.d/demonsaw
@@ -1,0 +1,32 @@
+# The following part always gets executed.
+# You must update the file paths for your system.
+echo "Demonsaw autoboot in /etc/init.d/demonsaw is running!"
+
+# The following part carries out specific functions depending on the arguments.
+
+case "$1" in
+	start)
+	echo "Starting Demonsaw Now!"
+	cd /var/demonsaw
+        sudo ./demonsaw-screen.sh
+	
+	;;
+
+        stop)
+        echo "trying to pkill demonsaw"
+        # pkill should not normally be used as it will stop any process identified.
+        # This is the best way I could find to kill the server when needed.
+        sudo pkill demonsaw
+        echo "Demonsaw should now be killed!"
+
+        ;;
+	
+	*)
+	
+	echo "usage: /etc/init.d/demonsaw {start|stop}"
+	exit 1
+	;;
+
+esac
+
+exit 0


### PR DESCRIPTION
Using this script will cause your Debian based system to autostart your Demonsaw server at boot.

After uploading the file demonsaw to your /etc/init.d folder you need to then run these sudo commands below in this text to make it work right in most cases.

Make the init.d script executable
$ sudo chmod 755 /etc/init.d/demonsaw

Add the init.d script to a default runlevel, so that the script can be called at boot time (and also during shutdown).
$ sudo update-rc.d demonsaw defaults

now you can type in the terminal
/etc/init.d/demonsaw
and you will get a list of commands{start | stop}

so to use the demonsaw server commands run the following in terminal: 
/etc/init.d/demonsaw start
/etc/init.d/demonsaw stop
each command does what it says.

Later if you decide to remove the init.d script from the start-up service list, you can simply run the following.

$ sudo update-rc.d -f demonsaw remove
